### PR TITLE
Defined MSLSP_BASE_DIR environment variable in bash scripts.

### DIFF
--- a/MSLSP_Parameters.json
+++ b/MSLSP_Parameters.json
@@ -38,12 +38,12 @@
   
     "SCC":{
     
-    "workDir":"/projectnb/modislc/users/aliceni/MSLSP/output/S10/",
-    "logDir":"/projectnb/modislc/users/aliceni/MSLSP/runLogs/",
-    "dataDir":"/projectnb/modislc/users/aliceni/MSLSP/input/",
-    "rScript":"/projectnb/modislc/users/aliceni/MSLSP/MSLSP_Script_dev.R",
-    "rFunctions":"/projectnb/modislc/users/aliceni/MSLSP/MSLSP_Functions_dev.R",
-    "productTable":"/projectnb/modislc/users/aliceni/MSLSP/MSLSP_Layers.csv",
+    "workDir":"output/S10/",
+    "logDir":"runLogs/",
+    "dataDir":"input/",
+    "rScript":"MSLSP_Script_dev.R",
+    "rFunctions":"MSLSP_Functions_dev.R",
+    "productTable":"MSLSP_Layers.csv",
     
     "numCores":16,
     "numChunks":48,

--- a/SCC/MSLSP_runTile_SCC.sh
+++ b/SCC/MSLSP_runTile_SCC.sh
@@ -1,6 +1,10 @@
 #!/bin/bash -l
 #$ -j y
 
+# Get the base directory path based on the location of this launching script.
+MSLSP_BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. &> /dev/null && pwd )"
+echo "MSLSP Base directory: $MSLSP_BASE_DIR"
+
 #SCC
 #Load packages
 #######
@@ -21,11 +25,11 @@ parameters=$2
 timeStamp=$3
 
 
-rScript=$( jq --raw-output .SCC.rScript $parameters )
-dataDir=$( jq --raw-output .SCC.dataDir $parameters )
-workDir=$( jq --raw-output .SCC.workDir $parameters )
-imgDir=$( jq --raw-output .dirs.imgDir $parameters )
-logDir=$( jq --raw-output .SCC.logDir $parameters ) 
+rScript=$MSLSP_BASE_DIR/$( jq --raw-output .SCC.rScript $parameters )
+dataDir=$MSLSP_BASE_DIR/$( jq --raw-output .SCC.dataDir $parameters )
+workDir=$MSLSP_BASE_DIR/$( jq --raw-output .SCC.workDir $parameters )
+imgDir=$MSLSP_BASE_DIR/$( jq --raw-output .dirs.imgDir $parameters )
+logDir=$MSLSP_BASE_DIR/$( jq --raw-output .SCC.logDir $parameters ) 
 numCores=$( jq --raw-output .SCC.numCores $parameters ) 
 
 

--- a/SCC/MSLSP_submitTiles_SCC.sh
+++ b/SCC/MSLSP_submitTiles_SCC.sh
@@ -1,15 +1,19 @@
 module load jq
 
-parameters="/projectnb/modislc/users/aliceni/MSLSP/MSLSP_Parameters.json"
-tileList="/projectnb/modislc/users/aliceni/MSLSP/SCC/tileLists/arizona.txt"
+# Get the base directory path based on the location of this launching script.
+MSLSP_BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. &> /dev/null && pwd )"
+echo "Base directory: $MSLSP_BASE_DIR"
+
+parameters="$MSLSP_BASE_DIR/MSLSP_Parameters.json"
+tileList="$MSLSP_BASE_DIR/SCC/tileLists/arizona.txt"
 
 numCores=$( jq .SCC.numCores $parameters )
-workDir=$( jq --raw-output .SCC.workDir $parameters )
-dataDir=$( jq --raw-output .SCC.dataDir $parameters )
+workDir=$MSLSP_BASE_DIR/$( jq --raw-output .SCC.workDir $parameters )
+dataDir=$MSLSP_BASE_DIR/$( jq --raw-output .SCC.dataDir $parameters )
 
 jobTime="$(date +%Y_%m_%d_%H_%M_%S)"
 
-logDir=$( jq --raw-output .SCC.logDir $parameters ) 
+logDir=$MSLSP_BASE_DIR/$( jq --raw-output .SCC.logDir $parameters ) 
 mkdir -p $logDir
 
 if $(jq .SCC.runS10 $parameters )
@@ -55,7 +59,7 @@ then
         downloadArg="-l download"
         imgStartYr=$(( $( jq .setup.imgStartYr $parameters ) - 1 ))
         imgEndYr=$(( $( jq .setup.imgEndYr $parameters ) + 1 ))
-        qsub $nameArg $logArg_download $downloadArg /projectnb/modislc/users/aliceni/MSLSP/SCC/runDownloadHLS.sh $tile $baseDir $imgStartYr $imgEndYr
+        qsub $nameArg $logArg_download $downloadArg $MSLSP_BASE_DIR/SCC/runDownloadHLS.sh $tile $baseDir $imgStartYr $imgEndYr
     done < $tileList
 
     while read -r tile
@@ -65,7 +69,7 @@ then
         nameArg="-N R_${tile}"
         logArg="-o ${logDir}Run_${tile}_${jobTime}.txt"
         holdArg="-hold_jid DL_${tile}"
-        qsub $nameArg $logArg $nodeArgs $holdArg /projectnb/modislc/users/aliceni/MSLSP/SCC/MSLSP_runTile_SCC.sh $tile $paramName $jobTime
+        qsub $nameArg $logArg $nodeArgs $holdArg $MSLSP_BASE_DIR/SCC/MSLSP_runTile_SCC.sh $tile $paramName $jobTime
     done < $tileList
 elif [ $(jq .setup.downloadImagery $parameters ) == true ] && [ $(jq .SCC.runS10 $parameters ) == true ]
 then
@@ -76,7 +80,7 @@ then
         downloadArg="-l download"
         imgStartYr=$(( $( jq .setup.imgStartYr $parameters ) - 1 ))
         imgEndYr=$(( $( jq .setup.imgEndYr $parameters ) + 1 ))
-        qsub $nameArg $logArg_download $downloadArg /projectnb/modislc/users/aliceni/MSLSP/S10_scripts/runDownloadS10.sh $tile $baseDir $imgStartYr $imgEndYr $tileJsonDir
+        qsub $nameArg $logArg_download $downloadArg $MSLSP_BASE_DIR/S10_scripts/runDownloadS10.sh $tile $baseDir $imgStartYr $imgEndYr $tileJsonDir
     done < $tileList
     
     while read -r tile
@@ -86,7 +90,7 @@ then
       nameArg="-N R_${tile}"
       logArg="-o ${logDir}Run_${tile}_${jobTime}.txt"
       holdArg="-hold_jid DL_S10_${tile}"
-      qsub $nameArg $logArg $nodeArgs $holdArg /projectnb/modislc/users/aliceni/MSLSP/SCC/MSLSP_runTile_SCC.sh $tile $paramName $jobTime
+      qsub $nameArg $logArg $nodeArgs $holdArg $MSLSP_BASE_DIR/SCC/MSLSP_runTile_SCC.sh $tile $paramName $jobTime
     done < $tileList
 else
     while read -r tile
@@ -95,7 +99,7 @@ else
         paramName="${tileDir}parameters_${jobTime}.json"
         nameArg="-N R_${tile}"
         logArg="-o ${logDir}Run_${tile}_${jobTime}.txt"
-        qsub $nameArg $logArg $nodeArgs /projectnb/modislc/users/aliceni/MSLSP/SCC/MSLSP_runTile_SCC.sh $tile $paramName $jobTime
+        qsub $nameArg $logArg $nodeArgs $MSLSP_BASE_DIR/SCC/MSLSP_runTile_SCC.sh $tile $paramName $jobTime
     done < $tileList
 fi
 

--- a/SCC/runDownloadHLS.sh
+++ b/SCC/runDownloadHLS.sh
@@ -1,6 +1,10 @@
 #!/bin/bash -l
 #$ -j y
 
+# Get the base directory path based on the location of this launching script.
+MSLSP_BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. &> /dev/null && pwd )"
+echo "Base directory: $BASE_DIR"
+
 
 tile=$1
 baseDir=$2
@@ -18,7 +22,7 @@ do
    
    imgSD="${y}-01-01"
    imgED="${y}-12-31"
-   /projectnb/modislc/users/aliceni/MSLSP/MSLSP/SCC/getHLS.sh $tile $imgSD $imgED $imgDir
+   $MSLSP_BASE_DIR/SCC/getHLS.sh $tile $imgSD $imgED $imgDir
    
 done
 


### PR DESCRIPTION
This is a minor update to the bash scripts and json parameter file.  I included the following commands at the top of the bash scripts:

<pre><code>
# Get the base directory path based on the location of this launching script.
<b>MSLSP_BASE_DIR</b>="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. &> /dev/null && pwd )"
echo "MSLSP Base directory: $MSLSP_BASE_DIR"
</code></pre>

The MSLSP_BASE_DIR environment variable contains the path to the MSLSP base directory.  So no matter where this repository is cloned, the MSLSP_BASE_DIR will contain the full path to the MSLSP directory of the cloned repo, which can be used to construct paths to other scripts and directories.

<pre><code>
rScript=<b>$MSLSP_BASE_DIR</b>/$( jq --raw-output .SCC.rScript $parameters )
dataDir=<b>$MSLSP_BASE_DIR</b>/$( jq --raw-output .SCC.dataDir $parameters )
workDir=<b>$MSLSP_BASE_DIR</b>/$( jq --raw-output .SCC.workDir $parameters )
imgDir=<b>$MSLSP_BASE_DIR</b>/$( jq --raw-output .dirs.imgDir $parameters )
logDir=<b>$MSLSP_BASE_DIR</b>/$( jq --raw-output .SCC.logDir $parameters ) 
</code></pre>

<pre><code>
qsub $nameArg $logArg_download $downloadArg <b>$MSLSP_BASE_DIR</b>/SCC/runDownloadHLS.sh $tile $baseDir $imgStartYr $imgEndYr
</code></pre>

This then allows the removal of some hard coded paths scattered throughout the bash scripts and allows the parameters.json file to contain relative paths in relation to the base directory.

```json
"workDir":"output/S10/",
"logDir":"runLogs/",
"dataDir":"input/",
"rScript":"MSLSP_Script_dev.R",
"rFunctions":"MSLSP_Functions_dev.R",
"productTable":"MSLSP_Layers.csv",
```

This will should reduce the number of hard coded paths that need to be updated if someone else tries to run the code, like me.
