### PR TITLE
Resolved a bug with imgDir variable in MSLSP_runTile_SCC.sh

### DIFF
--- a/SCC/MSLSP_runTile_SCC.sh
+++ b/SCC/MSLSP_runTile_SCC.sh
@@ -28,7 +28,7 @@ timeStamp=$3
 rScript=$MSLSP_BASE_DIR/$( jq --raw-output .SCC.rScript $parameters )
 dataDir=$MSLSP_BASE_DIR/$( jq --raw-output .SCC.dataDir $parameters )
 workDir=$MSLSP_BASE_DIR/$( jq --raw-output .SCC.workDir $parameters )
-imgDir=$MSLSP_BASE_DIR/$( jq --raw-output .dirs.imgDir $parameters )
+imgDir=$( jq --raw-output .dirs.imgDir $parameters )
 logDir=$MSLSP_BASE_DIR/$( jq --raw-output .SCC.logDir $parameters ) 
 numCores=$( jq --raw-output .SCC.numCores $parameters ) 
 


### PR DESCRIPTION
This is a bug I introduced accidently with my last pull request and I found it today.

In MSLSP_submitTiles_SCC.sh a parameter "dirs.imgDir" is added to the json file with the full path to the img directory.  In MSLSP_runTile_SCC.sh, the $MSLSP_BASE_DIR is pre-appended, creating a non-sense path. So I removed the a pre-appending $MSLSP_BASE_DIR path for dirs.imgDir.

Let me know if there are any questions.

